### PR TITLE
Introduce a hard limit on the number of SSIDs that we send up to limi…

### DIFF
--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -47,7 +47,7 @@ module PatronusFati::DataModels
           active: active?,
           connected_clients: connected_clients.map(&:bssid),
           vendor: vendor,
-          ssids: current_ssids.ordered_limit(8).map(&:full_state)
+          ssids: current_ssids.ordered_limit(16).map(&:full_state)
         )
     end
   end

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -47,7 +47,7 @@ module PatronusFati::DataModels
           active: active?,
           connected_clients: connected_clients.map(&:bssid),
           vendor: vendor,
-          ssids: current_ssids.map(&:full_state)
+          ssids: current_ssids.limit_tst(8).map(&:full_state)
         )
     end
   end

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -47,7 +47,7 @@ module PatronusFati::DataModels
           active: active?,
           connected_clients: connected_clients.map(&:bssid),
           vendor: vendor,
-          ssids: current_ssids.limit_tst(8).map(&:full_state)
+          ssids: current_ssids.ordered_limit(8).map(&:full_state)
         )
     end
   end

--- a/lib/patronus_fati/data_models/common.rb
+++ b/lib/patronus_fati/data_models/common.rb
@@ -64,7 +64,7 @@ module PatronusFati
           all(:last_seen_at.lt => current_expiration_threshold)
         end
 
-        def limit_tst(num)
+        def ordered_limit(num)
           all(:limit => num, :order => [ :last_seen_at.desc ])
         end
       end

--- a/lib/patronus_fati/data_models/common.rb
+++ b/lib/patronus_fati/data_models/common.rb
@@ -63,6 +63,10 @@ module PatronusFati
         def inactive
           all(:last_seen_at.lt => current_expiration_threshold)
         end
+
+        def limit_tst(num)
+          all(:limit => num, :order => [ :last_seen_at.desc ])
+        end
       end
     end
   end


### PR DESCRIPTION
…t processing requirements on the DP side

Pretty straight forward, this only sends up the 16 most recently seen SSIDs associated with an AP. This is primarily to help limit the impact of Evil AP when set to automatically spoof SSIDs in a very active environment.
