### PR TITLE
Support diagnositc dumping

### DIFF
--- a/bin/patronus_fati
+++ b/bin/patronus_fati
@@ -46,7 +46,7 @@ exception_logger('process') do
         event_type: event_type,
         data: msg,
         diagnostics: diagnostics,
-        timestamp: Time.now
+        timestamp: Time.now.to_i
       }
     ))
   end

--- a/bin/patronus_fati
+++ b/bin/patronus_fati
@@ -39,8 +39,16 @@ exception_logger('process') do
   connection = PatronusFati.setup(options['server'], options['port'])
   connection.connect
 
-  PatronusFati.event_handler.on(:any) do |asset_type, event_type, msg, _|
-    PatronusFati.logger.info(JSON.generate({asset_type: asset_type, event_type: event_type, data: msg, timestamp: Time.now}))
+  PatronusFati.event_handler.on(:any) do |asset_type, event_type, msg, diagnostics|
+    PatronusFati.logger.info(JSON.generate(
+      {
+        asset_type: asset_type,
+        event_type: event_type,
+        data: msg,
+        diagnostics: diagnostics,
+        timestamp: Time.now
+      }
+    ))
   end
 
   while (line = connection.read_queue.pop)

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -73,6 +73,7 @@ module PatronusFati
 
       def diagnostic_data
         {
+          sync_status: sync_status,
           current_presence: presence.current_presence.bits,
           last_presence: presence.last_presence.bits,
           ssids: ssids.map { |k, s| [k, s.diagnostic_data] }

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -56,10 +56,11 @@ module PatronusFati
       def cleanup_ssids
         return if ssids.select { |_, v| v.presence.dead? }.empty?
 
-        # When an AP is offline we don't care about it's SSIDs
-        # expiring
+        # When an AP is offline we don't care about announcing that it's SSIDs
+        # have expired, but we do want to remove them.
         set_sync_flag(:dirtyChildren) if active? && !status_dirty?
-        ssids.reject { |_, v| v.presence.dead? }
+
+        ssids.reject! { |_, v| v.presence.dead? }
       end
 
       def diagnostic_data

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -37,14 +37,16 @@ module PatronusFati
           PatronusFati.event_handler.event(
             :access_point,
             status,
-            full_state
+            full_state,
+            diagnostic_data
           )
         else
           PatronusFati.event_handler.event(
             :access_point, :offline, {
               'bssid' => local_attributes[:bssid],
               'uptime' => presence.visible_time
-            }
+            },
+            diagnostic_data
           )
 
           # We need to reset the first seen so we get fresh duration
@@ -67,6 +69,14 @@ module PatronusFati
         # expiring
         set_sync_flag(:dirtyChildren) if active? && !status_dirty?
         ssids.reject { |_, v| v.presence.dead? }
+      end
+
+      def diagnostic_data
+        {
+          current_presence: presence.current_presence.bits,
+          last_presence: presence.last_presence.bits,
+          ssids: ssids.map { |k, s| [k, s.diagnostic_data] }
+        }
       end
 
       def full_state

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -8,16 +8,8 @@ module PatronusFati
 
       LOCAL_ATTRIBUTE_KEYS = [ :bssid, :channel, :type ].freeze
 
-      def self.[](bssid)
-        instances[bssid] ||= new(bssid)
-      end
-
       def self.current_expiration_threshold
         Time.now.to_i - AP_EXPIRATION
-      end
-
-      def self.instances
-        @instances ||= {}
       end
 
       def active_ssids
@@ -72,12 +64,7 @@ module PatronusFati
       end
 
       def diagnostic_data
-        {
-          sync_status: sync_status,
-          current_presence: presence.current_presence.bits,
-          last_presence: presence.last_presence.bits,
-          ssids: ssids.map { |k, s| [k, s.diagnostic_data] }
-        }
+        super.merge(ssids: ssids.map { |k, s| [k, s.diagnostic_data] })
       end
 
       def full_state
@@ -90,11 +77,10 @@ module PatronusFati
       end
 
       def initialize(bssid)
+        super
         self.local_attributes = { bssid: bssid }
         self.client_macs = []
-        self.presence = Presence.new
         self.ssids = {}
-        self.sync_status = 0
       end
 
       def mark_synced

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -12,7 +12,7 @@ module PatronusFati
       end
 
       def active_ssids
-        ssids.select { |_, v| v.active? }.values
+        ssids.select { |_, v| v.active? }
       end
 
       def add_client(mac)
@@ -64,14 +64,14 @@ module PatronusFati
       end
 
       def diagnostic_data
-        super.merge(ssids: ssids.map { |k, s| [k, s.diagnostic_data] })
+        super.merge(ssids: Hash[ssids.map { |k, s| [k, s.diagnostic_data] }])
       end
 
       def full_state
         local_attributes.merge({
           active: active?,
           connected_clients: client_macs,
-          ssids: active_ssids.map(&:local_attributes),
+          ssids: active_ssids.values.map(&:local_attributes),
           vendor: vendor
         })
       end

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -58,7 +58,7 @@ module PatronusFati
 
         # When an AP is offline we don't care about announcing that it's SSIDs
         # have expired, but we do want to remove them.
-        set_sync_flag(:dirtyChildren) if active? && !status_dirty?
+        set_sync_flag(:dirtyChildren) if active?
 
         ssids.reject! { |_, v| v.presence.dead? }
       end

--- a/lib/patronus_fati/data_models/access_point.rb
+++ b/lib/patronus_fati/data_models/access_point.rb
@@ -3,8 +3,7 @@ module PatronusFati
     class AccessPoint
       include CommonState
 
-      attr_accessor :client_macs, :local_attributes, :presence, :ssids,
-        :sync_status
+      attr_accessor :client_macs, :local_attributes, :ssids
 
       LOCAL_ATTRIBUTE_KEYS = [ :bssid, :channel, :type ].freeze
 

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -42,6 +42,9 @@ module PatronusFati
         access_point_bssids << bssid unless access_point_bssids.include?(bssid)
       end
 
+      # Probes don't have an explicit visibility window so this will only
+      # remove probes that haven't been seen in the entire duration of the time
+      # we track any visibility.
       def cleanup_probes
         return if probes.select { |_, pres| pres.dead? }.empty?
         set_sync_flag(:dirtyChildren)

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -29,13 +29,14 @@ module PatronusFati
 
         if active?
           status = new? ? :new : :changed
-          PatronusFati.event_handler.event(:client, status, full_state)
+          PatronusFati.event_handler.event(:client, status, full_state, diagnostic_data)
         else
           PatronusFati.event_handler.event(
             :client, :offline, {
               'bssid' => local_attributes[:mac],
               'uptime' => presence.visible_time
-            }
+            },
+            diagnostic_data
           )
 
           # We need to reset the first seen so we get fresh duration information
@@ -59,6 +60,13 @@ module PatronusFati
 
         set_sync_flag(:dirtyChildren)
         probes.reject { |_, v| v.presence.dead? }
+      end
+
+      def diagnostic_data
+        {
+          current_presence: presence.current_presence.bits,
+          last_presence: presence.last_presence.bits
+        }
       end
 
       def full_state

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -43,10 +43,9 @@ module PatronusFati
       end
 
       def cleanup_probes
-        return if probes.select { |_, v| v.presence.dead? }.empty?
-
+        return if probes.select { |_, pres| pres.dead? }.empty?
         set_sync_flag(:dirtyChildren)
-        probes.reject { |_, v| v.presence.dead? }
+        probes.reject! { |_, pres| pres.dead? }
       end
 
       def full_state

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -3,8 +3,7 @@ module PatronusFati
     class Client
       include CommonState
 
-      attr_accessor :access_point_bssids, :local_attributes, :presence,
-        :probes, :sync_status
+      attr_accessor :access_point_bssids, :local_attributes, :probes
 
       LOCAL_ATTRIBUTE_KEYS = [ :mac, :channel ].freeze
 

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -64,6 +64,7 @@ module PatronusFati
 
       def diagnostic_data
         {
+          sync_status: sync_status,
           current_presence: presence.current_presence.bits,
           last_presence: presence.last_presence.bits
         }

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -11,6 +11,10 @@ module PatronusFati
         Time.now.to_i - CLIENT_EXPIRATION
       end
 
+      def add_access_point(bssid)
+        access_point_bssids << bssid unless access_point_bssids.include?(bssid)
+      end
+
       def announce_changes
         return unless dirty? && valid?
 
@@ -36,10 +40,6 @@ module PatronusFati
         end
 
         mark_synced
-      end
-
-      def add_access_point(bssid)
-        access_point_bssids << bssid unless access_point_bssids.include?(bssid)
       end
 
       # Probes don't have an explicit visibility window so this will only

--- a/lib/patronus_fati/data_models/client.rb
+++ b/lib/patronus_fati/data_models/client.rb
@@ -8,20 +8,8 @@ module PatronusFati
 
       LOCAL_ATTRIBUTE_KEYS = [ :mac, :channel ].freeze
 
-      def self.[](mac)
-        instances[mac] ||= new(mac)
-      end
-
       def self.current_expiration_threshold
         Time.now.to_i - CLIENT_EXPIRATION
-      end
-
-      def self.exists?(mac)
-        instances.key?(mac)
-      end
-
-      def self.instances
-        @instances ||= {}
       end
 
       def announce_changes
@@ -62,14 +50,6 @@ module PatronusFati
         probes.reject { |_, v| v.presence.dead? }
       end
 
-      def diagnostic_data
-        {
-          sync_status: sync_status,
-          current_presence: presence.current_presence.bits,
-          last_presence: presence.last_presence.bits
-        }
-      end
-
       def full_state
         {
           active: active?,
@@ -82,11 +62,10 @@ module PatronusFati
       end
 
       def initialize(mac)
+        super
         self.access_point_bssids = []
         self.local_attributes = { mac: mac }
-        self.presence = Presence.new
         self.probes = {}
-        self.sync_status = 0
       end
 
       def remove_access_point(bssid)

--- a/lib/patronus_fati/data_models/common_state.rb
+++ b/lib/patronus_fati/data_models/common_state.rb
@@ -13,13 +13,13 @@ module PatronusFati
         new? || data_dirty? || status_dirty?
       end
 
-      def new?
-        sync_status & (SYNC_FLAGS[:syncedOnline] | SYNC_FLAGS[:syncedOffline]) > 0
-      end
-
       def mark_synced
         flag = active? ? :syncedOnline : :syncedOffline
         self.sync_status = SYNC_FLAGS[flag]
+      end
+
+      def new?
+        !(sync_flag?(:syncedOnline) || sync_flag?(:syncedOffline))
       end
 
       def set_sync_flag(flag)

--- a/lib/patronus_fati/data_models/common_state.rb
+++ b/lib/patronus_fati/data_models/common_state.rb
@@ -17,6 +17,9 @@ module PatronusFati
 
       def self.included(klass)
         klass.extend(KlassMethods)
+        klass.class_eval do
+          attr_accessor :presence, :sync_status
+        end
       end
 
       def active?

--- a/lib/patronus_fati/data_models/common_state.rb
+++ b/lib/patronus_fati/data_models/common_state.rb
@@ -1,6 +1,24 @@
 module PatronusFati
   module DataModels
     module CommonState
+      module KlassMethods
+        def [](key)
+          instances[key] ||= new(key)
+        end
+
+        def exists?(mac)
+          instances.key?(mac)
+        end
+
+        def instances
+          @instances ||= {}
+        end
+      end
+
+      def self.included(klass)
+        klass.extend(KlassMethods)
+      end
+
       def active?
         presence.visible_since?(self.class.current_expiration_threshold)
       end
@@ -9,8 +27,21 @@ module PatronusFati
         sync_flag?(:dirtyAttributes) || sync_flag?(:dirtyChildren)
       end
 
+      def diagnostic_data
+        {
+          sync_status: sync_status,
+          current_presence: presence.current_presence.bits,
+          last_presence: presence.last_presence.bits
+        }
+      end
+
       def dirty?
         new? || data_dirty? || status_dirty?
+      end
+
+      def initialize(*_args)
+        self.presence = Presence.new
+        self.sync_status = 0
       end
 
       def mark_synced

--- a/lib/patronus_fati/data_models/common_state.rb
+++ b/lib/patronus_fati/data_models/common_state.rb
@@ -33,6 +33,7 @@ module PatronusFati
       def diagnostic_data
         {
           sync_status: sync_status,
+          presence_bit_offset: presence.current_bit_offset,
           current_presence: presence.current_presence.bits,
           last_presence: presence.last_presence.bits
         }

--- a/lib/patronus_fati/data_models/connection.rb
+++ b/lib/patronus_fati/data_models/connection.rb
@@ -42,6 +42,7 @@ module PatronusFati
 
       def diagnostic_data
         {
+          sync_status: sync_status,
           current_presence: presence.current_presence.bits,
           last_presence: presence.last_presence.bits
         }

--- a/lib/patronus_fati/data_models/connection.rb
+++ b/lib/patronus_fati/data_models/connection.rb
@@ -7,15 +7,11 @@ module PatronusFati
 
       def self.[](key)
         bssid, mac = key.split('^')
-        instances[key] ||= new(bssid, mac)
+        super(bssid, mac)
       end
 
       def self.current_expiration_threshold
         Time.now.to_i - CONNECTION_EXPIRATION
-      end
-
-      def self.instances
-        @instances ||= {}
       end
 
       def announce_changes
@@ -40,20 +36,11 @@ module PatronusFati
         super && !link_lost
       end
 
-      def diagnostic_data
-        {
-          sync_status: sync_status,
-          current_presence: presence.current_presence.bits,
-          last_presence: presence.last_presence.bits
-        }
-      end
-
       def initialize(bssid, mac)
+        super
         self.bssid = bssid
         self.link_lost = false
         self.mac = mac
-        self.presence = Presence.new
-        self.sync_status = 0
       end
 
       def full_state

--- a/lib/patronus_fati/data_models/connection.rb
+++ b/lib/patronus_fati/data_models/connection.rb
@@ -3,7 +3,7 @@ module PatronusFati
     class Connection
       include CommonState
 
-      attr_accessor :bssid, :link_lost, :mac, :presence, :sync_status
+      attr_accessor :bssid, :link_lost, :mac
 
       def self.[](key)
         bssid, mac = key.split('^')

--- a/lib/patronus_fati/data_models/connection.rb
+++ b/lib/patronus_fati/data_models/connection.rb
@@ -7,7 +7,7 @@ module PatronusFati
 
       def self.[](key)
         bssid, mac = key.split('^')
-        super(bssid, mac)
+        instances[key] ||= new(bssid, mac)
       end
 
       def self.current_expiration_threshold

--- a/lib/patronus_fati/data_models/connection.rb
+++ b/lib/patronus_fati/data_models/connection.rb
@@ -23,7 +23,7 @@ module PatronusFati
           DataModels::Client[mac].valid?
 
         state = active? ? :connect : :disconnect
-        PatronusFati.event_handler.event(:connection, state, full_state)
+        PatronusFati.event_handler.event(:connection, state, full_state, diagnostic_data)
 
         # We need to reset the first seen so we get fresh duration information
         presence.first_seen = nil
@@ -38,6 +38,13 @@ module PatronusFati
 
       def active?
         super && !link_lost
+      end
+
+      def diagnostic_data
+        {
+          current_presence: presence.current_presence.bits,
+          last_presence: presence.last_presence.bits
+        }
       end
 
       def initialize(bssid, mac)

--- a/lib/patronus_fati/data_models/ssid.rb
+++ b/lib/patronus_fati/data_models/ssid.rb
@@ -13,6 +13,13 @@ module PatronusFati
         Time.now.to_i - SSID_EXPIRATION
       end
 
+      def diagnostic_data
+        {
+          current_presence: presence.current_presence.bits,
+          last_presence: presence.last_presence.bits
+        }
+      end
+
       def initialize(essid)
         self.local_attributes = { essid: essid }
         self.presence = PatronusFati::Presence.new

--- a/lib/patronus_fati/data_models/ssid.rb
+++ b/lib/patronus_fati/data_models/ssid.rb
@@ -13,18 +13,9 @@ module PatronusFati
         Time.now.to_i - SSID_EXPIRATION
       end
 
-      def diagnostic_data
-        {
-          sync_status: sync_status,
-          current_presence: presence.current_presence.bits,
-          last_presence: presence.last_presence.bits
-        }
-      end
-
       def initialize(essid)
+        super
         self.local_attributes = { essid: essid }
-        self.presence = PatronusFati::Presence.new
-        self.sync_status = 0
       end
 
       def update(attrs)

--- a/lib/patronus_fati/data_models/ssid.rb
+++ b/lib/patronus_fati/data_models/ssid.rb
@@ -15,7 +15,10 @@ module PatronusFati
 
       def initialize(essid)
         super
-        self.local_attributes = { essid: essid }
+        self.local_attributes = {
+          cloaked: essid.nil? || essid.empty?,
+          essid: essid
+        }
       end
 
       def update(attrs)

--- a/lib/patronus_fati/data_models/ssid.rb
+++ b/lib/patronus_fati/data_models/ssid.rb
@@ -15,6 +15,7 @@ module PatronusFati
 
       def diagnostic_data
         {
+          sync_status: sync_status,
           current_presence: presence.current_presence.bits,
           last_presence: presence.last_presence.bits
         }

--- a/lib/patronus_fati/data_models/ssid.rb
+++ b/lib/patronus_fati/data_models/ssid.rb
@@ -3,7 +3,7 @@ module PatronusFati
     class Ssid
       include CommonState
 
-      attr_accessor :local_attributes, :presence, :sync_status
+      attr_accessor :local_attributes
 
       LOCAL_ATTRIBUTE_KEYS = [
         :beacon_info, :beacon_rate, :cloaked, :crypt_set, :essid, :max_rate

--- a/lib/patronus_fati/message_processor.rb
+++ b/lib/patronus_fati/message_processor.rb
@@ -34,6 +34,7 @@ module PatronusFati
 
     def self.offline_clients
       DataModels::Client.instances.each do |_, client|
+        client.cleanup_probes
         client.announce_changes
       end
 

--- a/lib/patronus_fati/message_processor.rb
+++ b/lib/patronus_fati/message_processor.rb
@@ -106,13 +106,13 @@ module PatronusFati
 
         PatronusFati::DataModels::AccessPoint.instances.each do |bssid, access_point|
           next unless access_point.active?
-          PatronusFati.event_handler.event(:access_point, :sync, access_point.full_state)
+          PatronusFati.event_handler.event(:access_point, :sync, access_point.full_state, access_point.diagnostic_data)
           access_points << bssid
         end
 
         PatronusFati::DataModels::Client.instances.each do |mac, client|
           next unless client.active?
-          PatronusFati.event_handler.event(:client, :sync, client.full_state)
+          PatronusFati.event_handler.event(:client, :sync, client.full_state, client.diagnostic_data)
           clients << mac
         end
 

--- a/lib/patronus_fati/presence.rb
+++ b/lib/patronus_fati/presence.rb
@@ -116,9 +116,13 @@ module PatronusFati
     end
 
     # Returns the duration in seconds of how long the specific object was
-    # absolutely seen.
+    # absolutely seen. One additional interval duration is added to this length
+    # as we consider to have seen the tracked object for the entire duration of
+    # the interval not the length from the start of one interval to the start
+    # of the last interval, which makes logical sense (1 bit set is 1 interval
+    # duration, not zero seconds).
     def visible_time
-      last_visible - first_seen if first_seen
+      (last_visible + INTERVAL_DURATION) - first_seen if first_seen
     end
   end
 end

--- a/spec/patronus_fati/data_models/access_point_spec.rb
+++ b/spec/patronus_fati/data_models/access_point_spec.rb
@@ -4,4 +4,84 @@ RSpec.describe(PatronusFati::DataModels::AccessPoint) do
   subject { described_class.new('66:77:88:99:aa:bb') }
 
   it_behaves_like 'a common stateful model'
+
+  context '#active_ssids'
+  context '#add_client'
+  context '#announce_changes'
+  context '#cleanup_ssids'
+  context '#diagnostic_data'
+  context '#full_state'
+  context '#initialize'
+  context '#mark_synced'
+  context '#remove_client'
+  context '#track_ssid'
+
+  context '#update' do
+    it 'should not set invalid keys' do
+      expect { subject.update(bad: 'key') }
+        .to_not change { subject.local_attributes }
+    end
+
+    it 'shouldn\'t modify the sync flags on invalid keys' do
+      expect { subject.update(other: 'key') }
+        .to_not change { subject.sync_status }
+    end
+
+    it 'shouldn\'t modify the sync flags if the values haven\'t changed' do
+      expect { subject.update(subject.local_attributes) }
+        .to_not change { subject.sync_status }
+    end
+
+    it 'should set the dirty attribute flag when a value has changed' do
+      expect { subject.update(channel: 9) }
+        .to change { subject.sync_status }
+      expect(subject.sync_flag?(:dirtyAttributes)).to be_truthy
+    end
+  end
+
+  context '#valid?' do
+    it 'should be true when all required attributes are set' do
+      subject.local_attributes = { bssid: 'something', channel: 4, type: 'adhoc' }
+      expect(subject).to be_valid
+    end
+
+    it 'should not be valid when the channel is 0' do
+      subject.local_attributes = { bssid: 'something', channel: 0, type: 'adhoc' }
+      expect(subject).to_not be_valid
+    end
+
+    it 'should be false when missing a required attribute' do
+      subject.local_attributes = { bssid: 'something', channel: 4 }
+      expect(subject).to_not be_valid
+    end
+  end
+
+  context '#vendor' do
+    it 'should short circuit if no BSSID is available' do
+      expect(Louis).to_not receive(:lookup)
+
+      subject.update(bssid: nil)
+      subject.vendor
+    end
+
+    it 'should use the Louis gem to perform it\'s lookup' do
+      inst = 'test string'
+      subject.update(bssid: inst)
+
+      expect(Louis).to receive(:lookup).with(inst).and_return({})
+      subject.vendor
+    end
+
+    it 'should default the long vendor name if it\'s available' do
+      result = { 'long_vendor' => 'correct', 'short_vendor' => 'bad' }
+      expect(Louis).to receive(:lookup).and_return(result)
+      expect(subject.vendor).to eql('correct')
+    end
+
+    it 'should fallback on the short vendor name if long isn\'t available' do
+      result = { 'short_vendor' => 'short' }
+      expect(Louis).to receive(:lookup).and_return(result)
+      expect(subject.vendor).to eql('short')
+    end
+  end
 end

--- a/spec/patronus_fati/data_models/access_point_spec.rb
+++ b/spec/patronus_fati/data_models/access_point_spec.rb
@@ -27,9 +27,33 @@ RSpec.describe(PatronusFati::DataModels::AccessPoint) do
     end
   end
 
-  context '#add_client'
+  context '#add_client' do
+    it 'should not add a client more than once' do
+      sample_mac = 'cc:bb:cc:bb:cc:bb'
+      subject.client_macs = [ sample_mac ]
+
+      expect { subject.add_client(sample_mac) }
+        .to_not change { subject.client_macs }
+    end
+
+    it 'should add a client if it\'s not presently in the list' do
+      sample_mac = 'ac:db:fc:4b:8c:0b'
+      subject.client_macs = []
+
+      expect { subject.add_client(sample_mac) }
+        .to change { subject.client_macs }.from([]).to([sample_mac])
+    end
+  end
+
+  # TODO:
   context '#announce_changes'
-  context '#cleanup_ssids'
+
+  context '#cleanup_ssids' do
+    it 'should not set the dirty children flag if there is nothing to change'
+    it 'should not set the dirty children flag when the AP is offline'
+    it 'should remove dead SSIDs from the SSID list'
+    it 'should set the dirty children flag when SSIDs have been removed while the AP is active'
+  end
 
   context '#diagnostic_data' do
     it 'should include all SSID diagnostic data' do

--- a/spec/patronus_fati/data_models/access_point_spec.rb
+++ b/spec/patronus_fati/data_models/access_point_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe(PatronusFati::DataModels::AccessPoint) do
   it_behaves_like 'a common stateful model'
 
   context '#active_ssids' do
-    it 'should return a hash' do
+    it 'should return a hash when ssids have been populated' do
+      subject.track_ssid(essid: 'test')
       expect(subject.active_ssids).to be_kind_of(Hash)
     end
 
@@ -106,13 +107,16 @@ RSpec.describe(PatronusFati::DataModels::AccessPoint) do
     end
 
     it 'should include the keys expected by pulse' do
+      subject.track_ssid(essid: 'test')
       subject.update(channel: 45, type: 'adhoc')
+
       [:active, :bssid, :channel, :connected_clients, :ssids, :type, :vendor].each do |k|
         expect(subject.full_state.key?(k)).to be_truthy
       end
     end
 
     it 'should include the attributes of active ssids' do
+      subject.ssids = {}
       ssid_dbl = double(PatronusFati::DataModels::Ssid)
       expect(subject).to receive(:active_ssids).and_return({ pnt: ssid_dbl })
       expect(ssid_dbl).to receive(:local_attributes).and_return('data')
@@ -129,11 +133,6 @@ RSpec.describe(PatronusFati::DataModels::AccessPoint) do
     it 'should initialize client_macs to an empty array' do
       expect(subject.client_macs).to be_kind_of(Array)
       expect(subject.client_macs).to be_empty
-    end
-
-    it 'should initialize ssids to an empty hash' do
-      expect(subject.ssids).to be_kind_of(Hash)
-      expect(subject.ssids).to be_empty
     end
   end
 
@@ -172,7 +171,7 @@ RSpec.describe(PatronusFati::DataModels::AccessPoint) do
     let(:valid_ssid_data) { { essid: 'test' } }
 
     it 'should create a new SSID instance if one doesn\'t already exist' do
-      expect(subject.ssids).to be_empty
+      expect(subject.ssids).to be_nil
       expect { subject.track_ssid(valid_ssid_data) }.to change { subject.ssids }
     end
 

--- a/spec/patronus_fati/data_models/access_point_spec.rb
+++ b/spec/patronus_fati/data_models/access_point_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe(PatronusFati::DataModels::AccessPoint) do
+  subject { described_class.new('66:77:88:99:aa:bb') }
+
+  it_behaves_like 'a common stateful model'
+end

--- a/spec/patronus_fati/data_models/client_spec.rb
+++ b/spec/patronus_fati/data_models/client_spec.rb
@@ -5,6 +5,24 @@ RSpec.describe(PatronusFati::DataModels::Client) do
 
   it_behaves_like 'a common stateful model'
 
+  context '#add_access_point' do
+    it 'should not add an access point more than once' do
+      sample_mac = '33:33:33:44:44:44'
+      subject.access_point_bssids = [ sample_mac ]
+
+      expect { subject.add_access_point(sample_mac) }
+        .to_not change { subject.access_point_bssids }
+    end
+
+    it 'should add an access point if it\'s not presently in the list' do
+      sample_mac = '99:11:22:ff:23:00'
+
+      expect(subject.access_point_bssids).to be_empty
+      expect { subject.add_access_point(sample_mac) }
+        .to change { subject.access_point_bssids }.from([]).to([sample_mac])
+    end
+  end
+
   context '#announce_changes' do
     before(:each) do
       PatronusFati::DataModels::AccessPoint.instance_variable_set(:@instances, nil)
@@ -169,24 +187,6 @@ RSpec.describe(PatronusFati::DataModels::Client) do
       expect(PatronusFati.event_handler)
         .to receive(:event).with(:client, :offline, anything, sample_data)
       subject.announce_changes
-    end
-  end
-
-  context '#add_access_point' do
-    it 'should not add an access point more than once' do
-      sample_mac = '33:33:33:44:44:44'
-      subject.access_point_bssids = [ sample_mac ]
-
-      expect { subject.add_access_point(sample_mac) }
-        .to_not change { subject.access_point_bssids }
-    end
-
-    it 'should add an access point if it\'s not presently in the list' do
-      sample_mac = '99:11:22:ff:23:00'
-
-      expect(subject.access_point_bssids).to be_empty
-      expect { subject.add_access_point(sample_mac) }
-        .to change { subject.access_point_bssids }.from([]).to([sample_mac])
     end
   end
 

--- a/spec/patronus_fati/data_models/client_spec.rb
+++ b/spec/patronus_fati/data_models/client_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe(PatronusFati::DataModels::Client) do
+  subject { described_class.new('00:11:22:33:44:55') }
+
+  it_behaves_like 'a common stateful model'
+end

--- a/spec/patronus_fati/data_models/client_spec.rb
+++ b/spec/patronus_fati/data_models/client_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe(PatronusFati::DataModels::Client) do
   it_behaves_like 'a common stateful model'
 
   context '#announce_changes' do
+    before(:each) do
+      PatronusFati::DataModels::AccessPoint.instance_variable_set(:@instances, nil)
+      PatronusFati::DataModels::Client.instance_variable_set(:@instances, nil)
+      PatronusFati::DataModels::Connection.instance_variable_set(:@instances, nil)
+    end
+
     it 'should emit no events when the client isn\'t valid' do
       expect(subject).to receive(:dirty?).and_return(true)
       expect(subject).to receive(:valid?).and_return(false)
@@ -41,11 +47,72 @@ RSpec.describe(PatronusFati::DataModels::Client) do
       subject.announce_changes
     end
 
-    it 'should emit a changed client event when dirty and synced as offline'
-    it 'should emit an offline client event when the client becomes inactive'
-    it 'should reset the presence first_seen value when announced offline'
-    it 'should remove itself from access points as a connected client when announced offline'
-    it 'should mark active connections with a lost link when announced offline'
+    it 'should emit a changed client event when dirty and synced as offline' do
+      subject.mark_synced
+      expect(subject.active?).to be_falsey
+
+      subject.presence.mark_visible
+
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :changed, anything, anything)
+      subject.announce_changes
+    end
+
+    it 'should emit an offline client event when the client becomes inactive' do
+      subject.presence.mark_visible
+      subject.mark_synced
+      expect(subject.active?).to be_truthy
+
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject).to receive(:active?).and_return(false).exactly(3).times
+
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :offline, anything, anything)
+      subject.announce_changes
+    end
+
+    it 'should reset the presence first_seen value when announced offline' do
+      subject.presence.mark_visible
+      subject.mark_synced
+      expect(subject.active?).to be_truthy
+
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject).to receive(:active?).and_return(false).exactly(3).times
+
+      expect { subject.announce_changes }
+        .to change { subject.presence.first_seen }.to(nil)
+    end
+
+    it 'should remove itself from access points as a connected client when announced offline' do
+      bssid = 'fa:eb:dc:45:23:67'
+      dbl = double(PatronusFati::DataModels::AccessPoint)
+      PatronusFati::DataModels::AccessPoint.instances[bssid] = dbl
+
+      subject.presence.mark_visible
+      subject.add_access_point(bssid)
+      subject.mark_synced
+
+      expect(dbl).to receive(:remove_client).with(subject.local_attributes[:mac])
+      expect(subject).to receive(:active?).and_return(false).exactly(3).times
+
+      subject.announce_changes
+    end
+
+    it 'should mark active connections with a lost link when announced offline' do
+      bssid = 'fa:eb:dc:45:23:67'
+      conn_key = "#{bssid}^#{subject.local_attributes[:mac]}"
+
+      dbl = double(PatronusFati::DataModels::Connection)
+      PatronusFati::DataModels::Connection.instances[conn_key] = dbl
+
+      subject.presence.mark_visible
+      subject.add_access_point(bssid)
+      subject.mark_synced
+
+      expect(dbl).to receive(:link_lost=).with(true)
+      expect(subject).to receive(:active?).and_return(false).exactly(3).times
+
+      subject.announce_changes
+    end
 
     it 'should mark itself as synced when announced' do
       expect(subject).to receive(:dirty?).and_return(true)
@@ -55,9 +122,47 @@ RSpec.describe(PatronusFati::DataModels::Client) do
       subject.announce_changes
     end
 
-    it 'should announce the full state of the client with online syncs'
-    it 'should announce a minimal state of the client with offline syncs'
-    it 'should announce the diagnostic data of the client'
+    it 'should announce the full state of the client with online syncs' do
+      subject.presence.mark_visible
+      subject.mark_synced
+
+      data_sample = { data: 'test' }
+
+      expect(subject).to receive(:dirty?).and_return(true)
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject).to receive(:full_state).and_return(data_sample)
+
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :changed, data_sample, anything)
+      subject.announce_changes
+    end
+
+    it 'should announce a minimal state of the client with offline syncs' do
+      subject.presence.mark_visible
+      subject.mark_synced
+
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject).to receive(:active?).and_return(false).exactly(3).times
+
+      expect(subject.presence).to receive(:visible_time).and_return(1234)
+      min_data = {
+        'bssid' => subject.local_attributes[:mac],
+        'uptime' => 1234
+      }
+
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :offline, min_data, anything)
+      subject.announce_changes
+    end
+
+    it 'should announce the diagnostic data of the client' do
+      sample_data = { content: 'diagnostic' }
+
+      expect(subject).to receive(:dirty?).and_return(true)
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject).to receive(:diagnostic_data).and_return(sample_data)
+
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :offline, anything, sample_data)
+      subject.announce_changes
+    end
   end
 
   context '#add_access_point'

--- a/spec/patronus_fati/data_models/client_spec.rb
+++ b/spec/patronus_fati/data_models/client_spec.rb
@@ -4,4 +4,69 @@ RSpec.describe(PatronusFati::DataModels::Client) do
   subject { described_class.new('00:11:22:33:44:55') }
 
   it_behaves_like 'a common stateful model'
+
+  context '#announce_changes' do
+    it 'should emit no events when the client isn\'t valid' do
+      expect(subject).to receive(:dirty?).and_return(true)
+      expect(subject).to receive(:valid?).and_return(false)
+
+      expect(PatronusFati.event_handler).to_not receive(:event)
+      subject.announce_changes
+    end
+
+    it 'should emit no events when the instance isn\'t dirty' do
+      expect(subject).to receive(:dirty?).and_return(false)
+
+      expect(PatronusFati.event_handler).to_not receive(:event)
+      subject.announce_changes
+    end
+
+    it 'should emit a new client event when dirty and unsynced' do
+      expect(subject).to receive(:dirty?).and_return(true)
+      expect(subject).to receive(:valid?).and_return(true)
+      subject.presence.mark_visible
+
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :new, anything, anything)
+      subject.announce_changes
+    end
+
+    it 'should emit a changed client event when dirty and synced as online' do
+      subject.presence.mark_visible
+      subject.mark_synced
+
+      expect(subject).to receive(:dirty?).and_return(true)
+      expect(subject).to receive(:valid?).and_return(true)
+
+      expect(PatronusFati.event_handler).to receive(:event).with(:client, :changed, anything, anything)
+      subject.announce_changes
+    end
+
+    it 'should emit a changed client event when dirty and synced as offline'
+    it 'should emit an offline client event when the client becomes inactive'
+    it 'should reset the presence first_seen value when announced offline'
+    it 'should remove itself from access points as a connected client when announced offline'
+    it 'should mark active connections with a lost link when announced offline'
+
+    it 'should mark itself as synced when announced' do
+      expect(subject).to receive(:dirty?).and_return(true)
+      expect(subject).to receive(:valid?).and_return(true)
+      expect(subject).to receive(:mark_synced)
+
+      subject.announce_changes
+    end
+
+    it 'should announce the full state of the client with online syncs'
+    it 'should announce a minimal state of the client with offline syncs'
+    it 'should announce the diagnostic data of the client'
+  end
+
+  context '#add_access_point'
+  context '#cleanup_probes'
+  context '#full_state'
+  context '#initialize'
+  context '#remove_access_point'
+  context '#track_probe'
+  context '#update'
+  context '#valid?'
+  context '#vendor'
 end

--- a/spec/patronus_fati/data_models/client_spec.rb
+++ b/spec/patronus_fati/data_models/client_spec.rb
@@ -136,12 +136,11 @@ RSpec.describe(PatronusFati::DataModels::Client) do
       subject.announce_changes
     end
 
-    it 'should mark itself as synced when announced' do
-      expect(subject).to receive(:dirty?).and_return(true)
+    it 'short not be dirty after being synced' do
       expect(subject).to receive(:valid?).and_return(true)
-      expect(subject).to receive(:mark_synced)
+      subject.update(channel: 8)
 
-      subject.announce_changes
+      expect { subject.announce_changes }.to change { subject.dirty? }.from(true).to(false)
     end
 
     it 'should announce the full state of the client with online syncs' do

--- a/spec/patronus_fati/data_models/client_spec.rb
+++ b/spec/patronus_fati/data_models/client_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe(PatronusFati::DataModels::Client) do
       inst = 'test string'
       subject.update(mac: inst)
 
-      expect(Louis).to receive(:lookup).and_return({})
+      expect(Louis).to receive(:lookup).with(inst).and_return({})
       subject.vendor
     end
 

--- a/spec/patronus_fati/data_models/connection_spec.rb
+++ b/spec/patronus_fati/data_models/connection_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe(PatronusFati::DataModels::Connection) do
+  subject { described_class.new('00:00:00:00:00:00', '34:34:34:34:34:34') }
+
+  it_behaves_like 'a common stateful model'
+end

--- a/spec/patronus_fati/data_models/ssid_spec.rb
+++ b/spec/patronus_fati/data_models/ssid_spec.rb
@@ -1,7 +1,57 @@
 require 'spec_helper'
 
 RSpec.describe(PatronusFati::DataModels::Ssid) do
-  subject { described_class.new('88:88:88:99:99:99') }
+  subject { described_class.new('BillWiTheScienceFi') }
 
   it_behaves_like 'a common stateful model'
+
+  context '#initialize' do
+    it 'should initialize the local attributes with the essid' do
+      expect(subject.local_attributes.keys).to include(:essid)
+      expect(subject.local_attributes[:essid]).to_not be_nil
+    end
+
+    it 'should initialize the local attributes with cloaked' do
+      expect(subject.local_attributes.keys).to include(:cloaked)
+    end
+
+    it 'should initialize the cloaked attribute to false if an essid is provided' do
+      expect(subject.local_attributes[:essid]).to_not be_nil
+      expect(subject.local_attributes[:essid].size).to be > 0
+      expect(subject.local_attributes[:cloaked]).to be_falsey
+    end
+
+    it 'should initialize the cloaked attribute to true if a nil essid is provided' do
+      subject = described_class.new(nil)
+      expect(subject.local_attributes[:cloaked]).to be_truthy
+    end
+
+    it 'should initialize the cloaked attribute to true if an empty essid is provided' do
+      subject = described_class.new('')
+      expect(subject.local_attributes[:cloaked]).to be_truthy
+    end
+  end
+
+  context '#update' do
+    it 'should not set invalid keys' do
+      expect { subject.update(bad: 'key') }
+        .to_not change { subject.local_attributes }
+    end
+
+    it 'shouldn\'t modify the sync flags on invalid keys' do
+      expect { subject.update(other: 'key') }
+        .to_not change { subject.sync_status }
+    end
+
+    it 'shouldn\'t modify the sync flags if the values haven\'t changed' do
+      expect { subject.update(subject.local_attributes) }
+        .to_not change { subject.sync_status }
+    end
+
+    it 'should set the dirty attribute flag when a value has changed' do
+      expect { subject.update(max_rate: 5) }
+        .to change { subject.sync_status }
+      expect(subject.sync_flag?(:dirtyAttributes)).to be_truthy
+    end
+  end
 end

--- a/spec/patronus_fati/data_models/ssid_spec.rb
+++ b/spec/patronus_fati/data_models/ssid_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe(PatronusFati::DataModels::Ssid) do
+  subject { described_class.new('88:88:88:99:99:99') }
+
+  it_behaves_like 'a common stateful model'
+end

--- a/spec/shared_examples/common_model_state.rb
+++ b/spec/shared_examples/common_model_state.rb
@@ -137,6 +137,16 @@ RSpec.shared_examples_for('a common stateful model') do
     end
   end
 
+  context '#initialize' do
+    it 'should initialize sync_status to zero' do
+      expect(subject.sync_status).to eql(0)
+    end
+
+    it 'should initialize a new presence instance' do
+      expect(subject.presence).to be_kind_of(PatronusFati::Presence)
+    end
+  end
+
   context '#mark_synced' do
     it 'should set the sync status to syncedOnline when active' do
       expect(subject).to receive(:active?).and_return(true)

--- a/spec/shared_examples/common_model_state.rb
+++ b/spec/shared_examples/common_model_state.rb
@@ -88,6 +88,24 @@ RSpec.shared_examples_for('a common stateful model') do
     end
   end
 
+  context '#diagnostic_data' do
+    it 'should be a hash' do
+      expect(subject.diagnostic_data).to be_kind_of(Hash)
+    end
+
+    it 'should include the raw sync_status value' do
+      data = subject.diagnostic_data
+      expect(data.keys).to include(:sync_status)
+      expect(data[:sync_status]).to eql(subject.sync_status)
+    end
+
+    it 'should include the raw presence information' do
+      data = subject.diagnostic_data
+      expect(data.keys).to include(:current_presence)
+      expect(data.keys).to include(:last_presence)
+    end
+  end
+
   context '#dirty?' do
     it 'should be dirty when it\'s new' do
       expect(subject).to receive(:new?).and_return(true)

--- a/spec/shared_examples/common_model_state.rb
+++ b/spec/shared_examples/common_model_state.rb
@@ -137,20 +137,67 @@ RSpec.shared_examples_for('a common stateful model') do
   end
 
   context '#set_sync_flag' do
-    it 'should not change the value when it\'s already set'
-    it 'should set the flag if it\'s not already set'
-    it 'should not change other flags when being set'
+    it 'should not change the value when it\'s already set' do
+      subject.set_sync_flag(:syncedOnline)
+      expect { subject.set_sync_flag(:syncedOnline) }
+        .to_not change { subject.sync_status }
+    end
+
+    it 'should set the flag if it\'s not already set' do
+      expect(subject.sync_flag?(:dirtyAttributes)).to be_falsey
+      subject.set_sync_flag(:dirtyAttributes)
+      expect(subject.sync_flag?(:dirtyAttributes)).to be_truthy
+    end
+
+    it 'should not change other flags when being set' do
+      subject.set_sync_flag(:dirtyChildren)
+      subject.set_sync_flag(:syncedOnline)
+
+      expect(subject.sync_flag?(:dirtyChildren)).to be_truthy
+    end
   end
 
   context '#status_dirty?' do
-    it 'should be true when inactive and marked as active'
-    it 'should be true when active and marked as inactive'
-    it 'should be false when status matches it\'s marking'
+    it 'should be true when inactive and marked as active' do
+      expect(subject).to receive(:active?).and_return(false)
+      subject.set_sync_flag(:syncedOnline)
+      expect(subject.status_dirty?).to be_truthy
+    end
+
+    it 'should be true when active and marked as inactive' do
+      expect(subject).to receive(:active?).and_return(true)
+      subject.set_sync_flag(:syncedOffline)
+      expect(subject.status_dirty?).to be_truthy
+    end
+
+    it 'should be false when status and marking are active' do
+      expect(subject).to receive(:active?).and_return(true)
+      subject.set_sync_flag(:syncedOnline)
+      expect(subject.status_dirty?).to be_falsey
+    end
+
+    it 'should be false when status and marking are inactive' do
+      expect(subject).to receive(:active?).and_return(false)
+      subject.set_sync_flag(:syncedOffline)
+      expect(subject.status_dirty?).to be_falsey
+    end
   end
 
   context '#sync_flag?' do
-    it 'should be true when the provided flag is set'
-    it 'should be false when the provided flag isn\'t set'
-    it 'should be flase when just another flag is set'
+    it 'should be true when the provided flag is set' do
+      expect { subject.set_sync_flag(:dirtyAttributes) }
+        .to change { subject.sync_flag?(:dirtyAttributes) }.from(false).to(true)
+    end
+
+    it 'should be false when the provided flag isn\'t set' do
+      subject.sync_status = 0
+      expect(subject.sync_flag?(:dirtyChildren)).to be_falsey
+    end
+
+    it 'should be false when just another flag is set' do
+      subject.sync_status = 0
+      subject.set_sync_flag(:dirtyAttributes)
+      expect(subject.sync_flag?(:syncedOffline)).to be_falsey
+    end
   end
 end

--- a/spec/shared_examples/common_model_state.rb
+++ b/spec/shared_examples/common_model_state.rb
@@ -1,0 +1,156 @@
+RSpec.shared_examples_for('a common stateful model') do
+  context '#active?' do
+    it 'should use it\'s expiration time against the presence instance' do
+      expect(described_class).to receive(:current_expiration_threshold).and_return(137)
+      expect(subject.presence).to receive(:visible_since?).with(137)
+
+      subject.active?
+    end
+
+    it 'should pass the presence result back' do
+      expect(subject.presence).to receive(:visible_since?).and_return(false)
+      expect(subject.active?).to be_falsey
+
+      expect(subject.presence).to receive(:visible_since?).and_return(true)
+      expect(subject.active?).to be_truthy
+    end
+
+    it 'should have an expiration time' do
+      expect(described_class).to respond_to(:current_expiration_threshold)
+      expect(described_class.current_expiration_threshold).to be_kind_of(Numeric)
+    end
+
+    it 'should have an expiration in the past' do
+      expect(described_class.current_expiration_threshold).to be <= Time.now.to_i
+    end
+  end
+
+  context '#data_dirty?' do
+    it 'should be false when no status flags have been set' do
+      subject.sync_status = PatronusFati::SYNC_FLAGS[:unsynced]
+      expect(subject.data_dirty?).to be_falsey
+    end
+
+    it 'should be false when only sync status flags are set' do
+      subject.sync_status = PatronusFati::SYNC_FLAGS[:syncedOffline]
+      expect(subject.data_dirty?).to be_falsey
+
+      subject.sync_status = PatronusFati::SYNC_FLAGS[:syncedOnline]
+      expect(subject.data_dirty?).to be_falsey
+    end
+
+    it 'should be true when the attributes have been marked dirty' do
+      subject.sync_status = PatronusFati::SYNC_FLAGS[:dirtyAttributes]
+      expect(subject.data_dirty?).to be_truthy
+    end
+
+    it 'should be true when a child has been marked dirty' do
+      subject.sync_status = PatronusFati::SYNC_FLAGS[:dirtyChildren]
+      expect(subject.data_dirty?).to be_truthy
+    end
+  end
+
+  context '#dirty?' do
+    it 'should be dirty when it\'s new' do
+      expect(subject).to receive(:new?).and_return(true)
+
+      expect(subject.dirty?).to be_truthy
+    end
+
+    it 'should be dirty if data has changed' do
+      expect(subject).to receive(:new?).and_return(false)
+      expect(subject).to receive(:data_dirty?).and_return(true)
+
+      expect(subject.dirty?).to be_truthy
+    end
+
+    it 'should be dirty if the sync status doesn\'t match or current status' do
+      expect(subject).to receive(:new?).and_return(false)
+      expect(subject).to receive(:data_dirty?).and_return(false)
+      expect(subject).to receive(:status_dirty?).and_return(true)
+
+      expect(subject.dirty?).to be_truthy
+    end
+
+    it 'should not be dirty when nothing has changed' do
+      expect(subject).to receive(:new?).and_return(false)
+      expect(subject).to receive(:data_dirty?).and_return(false)
+      expect(subject).to receive(:status_dirty?).and_return(false)
+
+      expect(subject.dirty?).to be_falsey
+    end
+  end
+
+  context '#mark_synced' do
+    it 'should set the sync status to syncedOnline when active' do
+      expect(subject).to receive(:active?).and_return(true)
+      expect { subject.mark_synced }
+        .to change { subject.sync_flag?(:syncedOnline) }.from(false).to(true)
+    end
+
+    it 'should set the sync status to syncedOffline when not active' do
+      expect(subject).to receive(:active?).and_return(false)
+      expect { subject.mark_synced }
+        .to change { subject.sync_flag?(:syncedOffline) }.from(false).to(true)
+    end
+
+    it 'should clear the dirty attribute flags' do
+      subject.set_sync_flag(:dirtyAttributes)
+      expect { subject.mark_synced }
+        .to change { subject.sync_flag?(:dirtyAttributes) }.from(true).to(false)
+
+      subject.set_sync_flag(:dirtyChildren)
+      expect { subject.mark_synced }
+        .to change { subject.sync_flag?(:dirtyChildren) }.from(true).to(false)
+    end
+  end
+
+  context 'new?' do
+    it 'should be true when unsynced' do
+      expect(subject.sync_status).to eql(PatronusFati::SYNC_FLAGS[:unsynced])
+      expect(subject.new?).to be_truthy
+    end
+
+    it 'should be false when syncedOnline is set' do
+      subject.set_sync_flag(:syncedOnline)
+      expect(subject.new?).to be_falsey
+    end
+
+    it 'should be false when syncedOffline is set' do
+      subject.set_sync_flag(:syncedOffline)
+      expect(subject.new?).to be_falsey
+    end
+
+    it 'should be true when just the dirty data attributes are set' do
+      expect(subject.sync_status).to eql(PatronusFati::SYNC_FLAGS[:unsynced])
+
+      subject.set_sync_flag(:dirtyAttributes)
+      subject.set_sync_flag(:dirtyChildren)
+
+      expect(subject.new?).to be_truthy
+    end
+  end
+
+  context '#presence' do
+    it { expect(subject).to respond_to(:presence) }
+    it { expect(subject.presence).to be_instance_of(PatronusFati::Presence) }
+  end
+
+  context '#set_sync_flag' do
+    it 'should not change the value when it\'s already set'
+    it 'should set the flag if it\'s not already set'
+    it 'should not change other flags when being set'
+  end
+
+  context '#status_dirty?' do
+    it 'should be true when inactive and marked as active'
+    it 'should be true when active and marked as inactive'
+    it 'should be false when status matches it\'s marking'
+  end
+
+  context '#sync_flag?' do
+    it 'should be true when the provided flag is set'
+    it 'should be false when the provided flag isn\'t set'
+    it 'should be flase when just another flag is set'
+  end
+end

--- a/spec/shared_examples/common_model_state.rb
+++ b/spec/shared_examples/common_model_state.rb
@@ -1,4 +1,42 @@
 RSpec.shared_examples_for('a common stateful model') do
+  context 'class methods' do
+    # Helper to ensure tests don't interfere with each other
+    before(:each) do
+      described_class.instance_variable_set(:@instances, nil)
+    end
+
+    context '#[]' do
+      it 'should create a new instance when the key doesn\'t exist' do
+        expect { described_class['test'] }.to change { described_class.instances.count }.from(0).to(1)
+        expect(described_class['test']).to be_instance_of(described_class)
+      end
+
+      it 'should return an existing instance when the key already exists' do
+        dbl = double(described_class)
+        described_class.instances['just^keyed'] = dbl
+        expect(described_class['just^keyed']).to eq(dbl)
+      end
+    end
+
+    context '#exists?' do
+      it 'should be true when an instance matching the key exists' do
+        described_class.instances['test'] = double(described_class)
+        expect(described_class.exists?('test')).to be_truthy
+      end
+
+      it 'should be false when there is no instance matching the key' do
+        expect(described_class.exists?('other')).to be_falsey
+      end
+    end
+
+    context '#instances' do
+      it 'should default to an empty hash' do
+        expect(described_class.instances).to be_kind_of(Hash)
+        expect(described_class.instances).to be_empty
+      end
+    end
+  end
+
   context '#active?' do
     it 'should use it\'s expiration time against the presence instance' do
       expect(described_class).to receive(:current_expiration_threshold).and_return(137)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ $LOAD_PATH.unshift(base_path) unless $LOAD_PATH.include?(base_path)
 require 'rspec'
 require 'simplecov'
 
+require 'shared_examples/common_model_state'
+
 SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.add_filter "/spec/"
 SimpleCov.add_filter do |source_file|


### PR DESCRIPTION
Mostly test coverage, the original intent was just supporting the exporting of diagnostic data which this does do. It ended up revealing a couple of bugs which have also been addressed by this.